### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
           
       - name: Publish to Docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           username: tattletech
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore